### PR TITLE
Add a filter to filter items

### DIFF
--- a/BulkMetadataEditorPlugin.php
+++ b/BulkMetadataEditorPlugin.php
@@ -43,6 +43,14 @@ class BulkMetadataEditorPlugin extends Omeka_Plugin_AbstractPlugin
      */
     public function hookAdminHead()
     {
+        $requestParams = Zend_Controller_Front::getInstance()->getRequest()->getParams();
+        $module = isset($requestParams['module']) ? $requestParams['module'] : 'default';
+        $controller = isset($requestParams['controller']) ? $requestParams['controller'] : 'index';
+        $action = isset($requestParams['action']) ? $requestParams['action'] : 'index';
+        if ($module != 'bulk-metadata-editor' || $controller != 'index' || $action != 'index') {
+            return;
+        }
+
         $language = array(
             'PleaseWait' => __('Please wait...'),
             'Title' => __('Title'),
@@ -94,10 +102,9 @@ class BulkMetadataEditorPlugin extends Omeka_Plugin_AbstractPlugin
         $args['acl']->addResource('BulkMetadataEditor_Index');
     }
 
-   
     /**
      * Add the BulkMetadataEditor link to the admin main navigation.
-     * 
+     *
      * @param array $nav Navigation array.
      * @return array $nav Filtered navigation array.
      */
@@ -111,5 +118,5 @@ class BulkMetadataEditorPlugin extends Omeka_Plugin_AbstractPlugin
         );
         return $nav;
     }
-    
+
 }

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Copyright
 
 
 [Bulk Metadata Editor]: https://github.com/UCSCLibrary/BulkMetadataEditor
-[Omeka]: http://omeka.org
+[Omeka]: https://omeka.org
 [User Survey]: https://docs.google.com/forms/d/1sfct41zxTelXFlyBwtsT1u33nRl7GGofSTt06d1SDMQ/viewform?usp=send_form
 [plugin issues]: https://github.com/UCSCLibrary/BulkMetadataEditor/issues
 [GNU/GPL v3]: https://www.gnu.org/licenses/gpl-3.0.html

--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -38,9 +38,10 @@ class BulkMetadataEditor_IndexController extends Omeka_Controller_AbstractAction
      */
     public function indexAction()
     {
-        $this->view->form = new BulkMetadataEditor_Form_Main();
+        $form = new BulkMetadataEditor_Form_Main();
+        $this->view->form = apply_filters('bulk_metadata_editor_form', $form);
 
-        // if the form was submitted
+        // Check if the form was submitted.
         if ($this->getRequest()->isPost()
             && $this->view->form->isValid($this->getRequest()->getPost())) {
 
@@ -77,6 +78,7 @@ class BulkMetadataEditor_IndexController extends Omeka_Controller_AbstractAction
     {
         $params = $_REQUEST;
         $max = $this->_getParam('max');
+        unset($params['max']);
         try {
             $items = $this->_bulkEdit->getItems($params, $max);
             $total = $this->_bulkEdit->countItems($params);
@@ -103,6 +105,7 @@ class BulkMetadataEditor_IndexController extends Omeka_Controller_AbstractAction
     {
         $params = $_REQUEST;
         $max = $this->_getParam('max');
+        unset($params['max']);
         try {
             $items = $this->_bulkEdit->getItems($params);
             $fields = $this->_bulkEdit->getFields($params, $items, $max);
@@ -129,6 +132,7 @@ class BulkMetadataEditor_IndexController extends Omeka_Controller_AbstractAction
     {
         $params = $_REQUEST;
         $max = $this->_getParam('max');
+        unset($params['max']);
         try {
             $items = $this->_bulkEdit->getItems($params);
             $changes = $this->_bulkEdit->getChanges($params, $max);

--- a/libraries/BulkMetadataEditor/Form/Main.php
+++ b/libraries/BulkMetadataEditor/Form/Main.php
@@ -157,6 +157,7 @@ class BulkMetadataEditor_Form_Main extends Omeka_Form
             'multiOptions' => array(
                 'replace' => __('Search and replace text'),
                 'add' => __('Add a new metadatum in the selected field'),
+                'prepend' => __('Prepend text to existing metadata in the selected fields'),
                 'append' => __('Append text to existing metadata in the selected fields'),
                 'explode' => __('Explode metadata with a separator in multiple elements in the selected fields'),
                 'deduplicate' => __('Deduplicate and remove empty metadata in the selected fields'),
@@ -221,6 +222,12 @@ class BulkMetadataEditor_Form_Main extends Omeka_Form
             'class' => 'elementHidden',
             'description' => __('Input text you want to add as metadata'),
         ));
+        $this->addElement('text', 'bmePrepend', array(
+            'label' => __('Text to Prepend'),
+            'id' => 'bulk-metadata-editor-prepend',
+            'class' => 'elementHidden',
+            'description' => __('Input text you want to prepend to metadata'),
+        ));
         $this->addElement('text', 'bmeAppend', array(
             'label' => __('Text to Append'),
             'id' => 'bulk-metadata-editor-append',
@@ -267,6 +274,7 @@ class BulkMetadataEditor_Form_Main extends Omeka_Form
             array(
                 'changesRadio',
                 'previewChangesButton',
+                'bmePrepend',
                 'bmeAppend',
                 'bmeExplode',
                 'regexp',

--- a/views/admin/javascripts/BulkMetadataEditor.js
+++ b/views/admin/javascripts/BulkMetadataEditor.js
@@ -11,6 +11,7 @@ jQuery(document).ready(function () {
         $('#changesRadio-replace-field').after($('#regexp-field'));
         $('#changesRadio-replace-field').after($('#bulk-metadata-editor-search-field'));
         $('#changesRadio-add-field').after($('#bulk-metadata-editor-add-field'));
+        $('#changesRadio-prepend-field').after($('#bulk-metadata-editor-prepend-field'));
         $('#changesRadio-append-field').after($('#bulk-metadata-editor-append-field'));
         $('#changesRadio-explode-field').after($('#bulk-metadata-editor-explode-field'));
         $('#changesRadio-deduplicate-field').after($('#bulk-metadata-editor-deduplicate-field'));
@@ -61,6 +62,7 @@ jQuery(document).ready(function () {
                 $('#bulk-metadata-editor-replace-field').show(300);
                 $('#regexp-field').show(300);
                 $('#bulk-metadata-editor-add-field').hide(300);
+                $('#bulk-metadata-editor-prepend-field').hide(300);
                 $('#bulk-metadata-editor-append-field').hide(300);
                 $('#bulk-metadata-editor-explode-field').hide(300);
                 $('#bulk-metadata-editor-deduplicate-field').hide(300);
@@ -74,6 +76,20 @@ jQuery(document).ready(function () {
                 $('#bulk-metadata-editor-replace-field').hide(300);
                 $('#regexp-field').hide(300);
                 $('#bulk-metadata-editor-add-field').show(300);
+                $('#bulk-metadata-editor-prepend-field').hide(300);
+                $('#bulk-metadata-editor-append-field').hide(300);
+                $('#bulk-metadata-editor-deduplicate-field').hide(300);
+                $('#bulk-metadata-editor-deduplicate-files-field').hide(300);
+            }
+        });
+
+        $('#changesRadio-prepend').change(function () {
+            if (this.checked) {
+                $('#bulk-metadata-editor-search-field').hide(300);
+                $('#bulk-metadata-editor-replace-field').hide(300);
+                $('#regexp-field').hide(300);
+                $('#bulk-metadata-editor-add-field').hide(300);
+                $('#bulk-metadata-editor-prepend-field').show(300);
                 $('#bulk-metadata-editor-append-field').hide(300);
                 $('#bulk-metadata-editor-explode-field').hide(300);
                 $('#bulk-metadata-editor-deduplicate-field').hide(300);
@@ -87,6 +103,7 @@ jQuery(document).ready(function () {
                 $('#bulk-metadata-editor-replace-field').hide(300);
                 $('#regexp-field').hide(300);
                 $('#bulk-metadata-editor-add-field').hide(300);
+                $('#bulk-metadata-editor-prepend-field').hide(300);
                 $('#bulk-metadata-editor-append-field').show(300);
                 $('#bulk-metadata-editor-explode-field').hide(300);
                 $('#bulk-metadata-editor-deduplicate-field').hide(300);
@@ -113,6 +130,7 @@ jQuery(document).ready(function () {
                 $('#bulk-metadata-editor-replace-field').hide(300);
                 $('#regexp-field').hide(300);
                 $('#bulk-metadata-editor-add-field').hide(300);
+                $('#bulk-metadata-editor-prepend-field').hide(300);
                 $('#bulk-metadata-editor-append-field').hide(300);
                 $('#bulk-metadata-editor-explode-field').hide(300);
                 $('#bulk-metadata-editor-deduplicate-field').show(300);
@@ -126,6 +144,7 @@ jQuery(document).ready(function () {
                 $('#bulk-metadata-editor-replace-field').hide(300);
                 $('#regexp-field').hide(300);
                 $('#bulk-metadata-editor-add-field').hide(300);
+                $('#bulk-metadata-editor-prepend-field').hide(300);
                 $('#bulk-metadata-editor-append-field').hide(300);
                 $('#bulk-metadata-editor-explode-field').hide(300);
                 $('#bulk-metadata-editor-deduplicate-field').hide(300);
@@ -138,6 +157,7 @@ jQuery(document).ready(function () {
                 $('#bulk-metadata-editor-search-field').hide(300);
                 $('#bulk-metadata-editor-replace-field').hide(300);
                 $('#regexp-field').hide(300);
+                $('#bulk-metadata-editor-prepend-field').hide(300);
                 $('#bulk-metadata-editor-append-field').hide(300);
                 $('#bulk-metadata-editor-explode-field').hide(300);
                 $('#bulk-metadata-editor-add-field').hide(300);

--- a/views/helpers/BulkEdit.php
+++ b/views/helpers/BulkEdit.php
@@ -42,6 +42,11 @@ class BulkMetadataEditor_View_Helper_BulkEdit extends Zend_View_Helper_Abstract
     {
         $select = $this->_getSelect($params);
 
+        $select = apply_filters('bulk_metadata_editor_get_items', $select, array(
+            'params' => $params,
+            'max' => $max,
+        ));
+
         // Get only the item ids when there is no max.
         if (empty($max)) {
             $select

--- a/views/helpers/BulkEdit.php
+++ b/views/helpers/BulkEdit.php
@@ -698,6 +698,46 @@ class BulkMetadataEditor_View_Helper_BulkEdit extends Zend_View_Helper_Abstract
                         $j++;
                         break;
 
+                    case 'prepend':
+                        if (!isset($params['bmePrepend']) || !strlen($params['bmePrepend'])) {
+                            throw new Exception(__('Please input some text to prepend'));
+                        }
+
+                        if (!isset($params['delimiter'])) {
+                            $params['delimiter'] = ' ';
+                        }
+
+                        try {
+                            $element = $itemObj->getElementById($field['element_id']);
+                            $eText = get_record_by_id('ElementText', $field['id']);
+
+                            $new = $params['bmePrepend'] . $params['delimiter'] . $eText->text;
+                        } catch (Exception $e) {
+                            throw $e;
+                        }
+
+                        $changes[] = array(
+                            'itemId' => $itemId,
+                            'item' => $itemTitle,
+                            'field' => $element->name,
+                            'old' => $eText->text,
+                            'new' => $new,
+                        );
+
+                        if ($perform) {
+                            $html = $new != strip_tags($new);
+                            try {
+                                $eText->delete();
+                                $itemObj->addTextForElement($element, $new, $html);
+                            } catch (Exception $e) {
+                                $message .= __('An error occurred: %s', $e->getMessage());
+                                _log($message, Zend_Log::ERR);
+                                continue 2;
+                            }
+                        }
+                        $j++;
+                        break;
+
                     case 'append':
                         if (!isset($params['bmeAppend']) || !strlen($params['bmeAppend'])) {
                             throw new Exception(__('Please input some text to append'));


### PR DESCRIPTION
Hi,

To fix this issue (https://forum.omeka.org/t/bulk-edit-from-parent-collections/2962), I added two filters.

- `bulk_metadata_editor_form` to modify the form, for example, to add a checkbox "Collection tree";
- `bulk_metadata_editor_get_items` for the select in getitems(), so now it is possible to modify the select() anywhere, for example in a specific plugin.

Sincerely,

Daniel Berthereau
Infodoc & Knowledge management