### PR TITLE
Fix dynamic property issue in IndexController.php.

### DIFF
--- a/controllers/IndexController.php
+++ b/controllers/IndexController.php
@@ -20,7 +20,7 @@
 class BulkMetadataEditor_IndexController extends Omeka_Controller_AbstractActionController
 {
 
-    protected $bulkEdit;
+    protected $_bulkEdit;
 
     public function init()
     {


### PR DESCRIPTION
The BulkMetadataEditor_IndexController class had a protected property named $bulkEdit, but methods throughout the class refer to $_bulkEdit. This produces a deprecation warning in PHP 8.2 due to the creation of a dynamic property. The easiest fix is to add the underscore to the property.